### PR TITLE
Clarify game file repair failure guidance

### DIFF
--- a/Launcher.App/Resources/Strings.en.resx
+++ b/Launcher.App/Resources/Strings.en.resx
@@ -1228,9 +1228,6 @@ Longer content wraps automatically.</value>
   <data name="Account_AddButton" xml:space="preserve">
     <value>Add Account</value>
   </data>
-  <data name="Account_BuyMinecraftButton" xml:space="preserve">
-    <value>Buy Minecraft</value>
-  </data>
   <data name="Account_EmptySelection" xml:space="preserve">
     <value>Select an account to view or change settings.</value>
   </data>
@@ -1406,7 +1403,7 @@ Longer content wraps automatically.</value>
     <value>Choose the account type to add.</value>
   </data>
   <data name="Dialog_AddOfflineAccountSubtitle" xml:space="preserve">
-    <value>If you do not yet own a legitimate copy of Minecraft, please always prioritize purchasing one.</value>
+    <value>Enter a local username for offline play.</value>
   </data>
   <data name="Dialog_AddMicrosoftAccountSubtitle" xml:space="preserve">
     <value>Complete sign-in on the Microsoft page that opens.</value>
@@ -1724,7 +1721,7 @@ Longer content wraps automatically.</value>
     <value>The game started, but the offline skin could not be loaded. The default skin will be used this time.</value>
   </data>
   <data name="Status_LaunchInstanceRepairFailed" xml:space="preserve">
-    <value>The current instance is missing critical files and cannot be repaired without adding a new version. Reinstall this instance or check the version files.</value>
+    <value>Game file verification failed. Enable "Automatically repair missing files" and try again. If it still fails, reinstall this instance or check the version files.</value>
   </data>
   <data name="Status_LaunchInstanceSelectedFormat" xml:space="preserve">
     <value>Current game switched to {0}</value>
@@ -2235,9 +2232,6 @@ Longer content wraps automatically.</value>
   </data>
   <data name="Status_OpenFeedbackPageFailed" xml:space="preserve">
     <value>Failed to open the feedback page. Please try again later.</value>
-  </data>
-  <data name="Status_OpenMinecraftPurchasePageFailed" xml:space="preserve">
-    <value>Failed to open the Minecraft purchase page. Please try again later.</value>
   </data>
   <data name="Status_OpenReferenceProjectFailed" xml:space="preserve">
     <value>Failed to open the reference project.</value>
@@ -3025,9 +3019,6 @@ The current game folder will be backed up first.</value>
   </data>
   <data name="Dialog_DeleteMultipleModsMessageFormat" xml:space="preserve">
     <value>Delete these {0} mods? They will be moved to the Recycle Bin when possible; otherwise they will be permanently deleted.</value>
-  </data>
-  <data name="Status_ModEnabledStateTargetExistsFormat" xml:space="preserve">
-    <value>{0} already exists. Operation failed.</value>
   </data>
   <data name="Status_SelectedModsEnabledFormat" xml:space="preserve">
     <value>Enabled {0} mods</value>

--- a/Launcher.App/Resources/Strings.ja-JP.resx
+++ b/Launcher.App/Resources/Strings.ja-JP.resx
@@ -1228,9 +1228,6 @@
   <data name="Account_AddButton" xml:space="preserve">
     <value>アカウントを追加</value>
   </data>
-  <data name="Account_BuyMinecraftButton" xml:space="preserve">
-    <value>Minecraft を購入</value>
-  </data>
   <data name="Account_EmptySelection" xml:space="preserve">
     <value>設定を表示または変更するアカウントを選択してください。</value>
   </data>
@@ -1406,7 +1403,7 @@
     <value>追加するアカウントの種類を選択してください。</value>
   </data>
   <data name="Dialog_AddOfflineAccountSubtitle" xml:space="preserve">
-    <value>正規版 Minecraft をまだお持ちでない場合は、正規版の購入を優先してご検討ください。</value>
+    <value>追加するオフラインアカウント名を入力してください。</value>
   </data>
   <data name="Dialog_AddMicrosoftAccountSubtitle" xml:space="preserve">
     <value>表示された Microsoft 公式ページでログインを完了してください。</value>
@@ -1724,7 +1721,7 @@
     <value>ゲームは起動しましたが、オフラインスキンを読み込めませんでした。今回はデフォルトスキンを使用します。</value>
   </data>
   <data name="Status_LaunchInstanceRepairFailed" xml:space="preserve">
-    <value>現在のインスタンスには重要なファイルが不足しており、新しいバージョンを追加せずに自動補完できません。このインスタンスを再インストールするか、バージョンファイルを確認してください。</value>
+    <value>ゲームファイルの検証に失敗しました。「不足ファイルを自動補完」を有効にして再試行してください。解決しない場合は、このインスタンスを再インストールするか、バージョンファイルを確認してください。</value>
   </data>
   <data name="Status_LaunchInstanceSelectedFormat" xml:space="preserve">
     <value>現在のゲームを {0} に切り替えました</value>
@@ -2235,9 +2232,6 @@
   </data>
   <data name="Status_OpenFeedbackPageFailed" xml:space="preserve">
     <value>フィードバックページを開けませんでした。しばらくしてからもう一度お試しください。</value>
-  </data>
-  <data name="Status_OpenMinecraftPurchasePageFailed" xml:space="preserve">
-    <value>Minecraft の購入ページを開けませんでした。しばらくしてからもう一度お試しください。</value>
   </data>
   <data name="Status_OpenReferenceProjectFailed" xml:space="preserve">
     <value>プロジェクトリンクを開けませんでした</value>
@@ -3025,9 +3019,6 @@
   </data>
   <data name="Dialog_DeleteMultipleModsMessageFormat" xml:space="preserve">
     <value>この {0} 個の mod を削除しますか？可能な場合はごみ箱に移動し、ごみ箱を利用できない場合は完全に削除します。</value>
-  </data>
-  <data name="Status_ModEnabledStateTargetExistsFormat" xml:space="preserve">
-    <value>{0} は既に存在するため、操作に失敗しました。</value>
   </data>
   <data name="Status_SelectedModsEnabledFormat" xml:space="preserve">
     <value>{0} 個の mod を有効化しました</value>

--- a/Launcher.App/Resources/Strings.resx
+++ b/Launcher.App/Resources/Strings.resx
@@ -418,7 +418,6 @@
   <data name="Launch_Button" xml:space="preserve"><value>启动游戏</value></data>
   <data name="Account_ListTitle" xml:space="preserve"><value>账户</value></data>
   <data name="Account_AddButton" xml:space="preserve"><value>添加账户</value></data>
-  <data name="Account_BuyMinecraftButton" xml:space="preserve"><value>购买 Minecraft</value></data>
   <data name="Account_EmptySelection" xml:space="preserve"><value>选择账号以浏览或修改设置。</value></data>
   <data name="Account_SkinHeader" xml:space="preserve"><value>皮肤</value></data>
   <data name="Account_CapeHeader" xml:space="preserve"><value>披风</value></data>
@@ -485,7 +484,7 @@
   <data name="Dialog_LoginSuccessTitle" xml:space="preserve"><value>登录成功</value></data>
   <data name="Dialog_LoginIncompleteTitle" xml:space="preserve"><value>登录未完成</value></data>
   <data name="Dialog_AddAccountSubtitle" xml:space="preserve"><value>选择要添加的账户类型。</value></data>
-  <data name="Dialog_AddOfflineAccountSubtitle" xml:space="preserve"><value>如果您尚未拥有正版 Minecraft，请始终优先考虑购入正版  Minecraft。</value></data>
+  <data name="Dialog_AddOfflineAccountSubtitle" xml:space="preserve"><value>输入要添加的离线账户名。</value></data>
   <data name="Dialog_AddMicrosoftAccountSubtitle" xml:space="preserve"><value>请在弹出的 Microsoft 官方页面完成登录。</value></data>
   <data name="Dialog_AddThirdPartyAccountSubtitle" xml:space="preserve"><value>填写外置认证服务器和账户信息。</value></data>
   <data name="Dialog_AddAccountResultSubtitle" xml:space="preserve"><value>点击确定返回账户列表。</value></data>
@@ -591,7 +590,7 @@
   <data name="Status_LaunchRuntimeAbnormalExit" xml:space="preserve"><value>游戏运行时异常退出，已记录诊断日志。</value></data>
   <data name="Status_LaunchFailed" xml:space="preserve"><value>启动失败，请稍后重试。</value></data>
   <data name="Status_LaunchOfflineSkinUnavailable" xml:space="preserve"><value>游戏已启动，但离线皮肤加载失败，本次将使用默认皮肤。</value></data>
-  <data name="Status_LaunchInstanceRepairFailed" xml:space="preserve"><value>当前实例缺少关键文件，且无法在不新增版本的情况下自动补齐，请重新安装该实例或检查版本文件。</value></data>
+  <data name="Status_LaunchInstanceRepairFailed" xml:space="preserve"><value>游戏文件校验失败。请启用“缺失文件自动补全”后重试；若仍失败，请重新安装该实例或检查版本文件。</value></data>
   <data name="Status_LaunchInstanceSelectedFormat" xml:space="preserve"><value>当前游戏已切换为 {0}</value></data>
   <data name="Status_LaunchInstanceSelectionFailed" xml:space="preserve"><value>当前游戏切换失败，请刷新后重试。</value></data>
   <data name="Status_LoadingVersions" xml:space="preserve"><value>正在获取 Minecraft 版本列表...</value></data>
@@ -762,7 +761,6 @@
   <data name="Status_OpenLaunchReportFailed" xml:space="preserve"><value>无法打开本次游戏报告，请稍后重试。</value></data>
   <data name="Status_OpenGithubRepositoryFailed" xml:space="preserve"><value>打开 GitHub 仓库失败</value></data>
   <data name="Status_OpenFeedbackPageFailed" xml:space="preserve"><value>打开反馈页面失败，请稍后重试。</value></data>
-  <data name="Status_OpenMinecraftPurchasePageFailed" xml:space="preserve"><value>无法打开 Minecraft 购买页面，请稍后重试。</value></data>
   <data name="Status_OpenReferenceProjectFailed" xml:space="preserve"><value>打开项目链接失败</value></data>
   <data name="Status_OpenRelatedWebsiteFailed" xml:space="preserve"><value>打开相关网站失败</value></data>
   <data name="Status_OpenResourceDetailsFailed" xml:space="preserve"><value>无法打开资源详情，请稍后重试</value></data>
@@ -1028,7 +1026,6 @@
   <data name="Dialog_DeleteModsTitle" xml:space="preserve"><value>删除模组</value></data>
   <data name="Dialog_DeleteSingleModMessageFormat" xml:space="preserve"><value>确认删除模组“{0}”吗？将优先移入系统回收站；回收站不可用时将直接删除。</value></data>
   <data name="Dialog_DeleteMultipleModsMessageFormat" xml:space="preserve"><value>确认删除这 {0} 个模组吗？将优先移入系统回收站；回收站不可用时将直接删除。</value></data>
-  <data name="Status_ModEnabledStateTargetExistsFormat" xml:space="preserve"><value>{0}已存在，操作失败</value></data>
   <data name="Status_SelectedModsEnabledFormat" xml:space="preserve"><value>已启用 {0} 个模组</value></data>
   <data name="Status_SelectedModsEnablePartialFailedFormat" xml:space="preserve"><value>已启用 {0} 个模组，{1} 个失败</value></data>
   <data name="Status_SelectedModsEnableFailed" xml:space="preserve"><value>启用所选模组失败，请稍后重试。</value></data>

--- a/Launcher.App/Resources/Strings.zh-Hans.resx
+++ b/Launcher.App/Resources/Strings.zh-Hans.resx
@@ -418,7 +418,6 @@
   <data name="Launch_Button" xml:space="preserve"><value>启动游戏</value></data>
   <data name="Account_ListTitle" xml:space="preserve"><value>账户</value></data>
   <data name="Account_AddButton" xml:space="preserve"><value>添加账户</value></data>
-  <data name="Account_BuyMinecraftButton" xml:space="preserve"><value>购买 Minecraft</value></data>
   <data name="Account_EmptySelection" xml:space="preserve"><value>选择账号以浏览或修改设置。</value></data>
   <data name="Account_SkinHeader" xml:space="preserve"><value>皮肤</value></data>
   <data name="Account_CapeHeader" xml:space="preserve"><value>披风</value></data>
@@ -485,7 +484,7 @@
   <data name="Dialog_LoginSuccessTitle" xml:space="preserve"><value>登录成功</value></data>
   <data name="Dialog_LoginIncompleteTitle" xml:space="preserve"><value>登录未完成</value></data>
   <data name="Dialog_AddAccountSubtitle" xml:space="preserve"><value>选择要添加的账户类型。</value></data>
-  <data name="Dialog_AddOfflineAccountSubtitle" xml:space="preserve"><value>如果您尚未拥有正版 Minecraft，请始终优先考虑购入正版  Minecraft。</value></data>
+  <data name="Dialog_AddOfflineAccountSubtitle" xml:space="preserve"><value>输入要添加的离线账户名。</value></data>
   <data name="Dialog_AddMicrosoftAccountSubtitle" xml:space="preserve"><value>请在弹出的 Microsoft 官方页面完成登录。</value></data>
   <data name="Dialog_AddThirdPartyAccountSubtitle" xml:space="preserve"><value>填写外置认证服务器和账户信息。</value></data>
   <data name="Dialog_AddAccountResultSubtitle" xml:space="preserve"><value>点击确定返回账户列表。</value></data>
@@ -591,7 +590,7 @@
   <data name="Status_LaunchRuntimeAbnormalExit" xml:space="preserve"><value>游戏运行时异常退出，已记录诊断日志。</value></data>
   <data name="Status_LaunchFailed" xml:space="preserve"><value>启动失败，请稍后重试。</value></data>
   <data name="Status_LaunchOfflineSkinUnavailable" xml:space="preserve"><value>游戏已启动，但离线皮肤加载失败，本次将使用默认皮肤。</value></data>
-  <data name="Status_LaunchInstanceRepairFailed" xml:space="preserve"><value>当前实例缺少关键文件，且无法在不新增版本的情况下自动补齐，请重新安装该实例或检查版本文件。</value></data>
+  <data name="Status_LaunchInstanceRepairFailed" xml:space="preserve"><value>游戏文件校验失败。请启用“缺失文件自动补全”后重试；若仍失败，请重新安装该实例或检查版本文件。</value></data>
   <data name="Status_LaunchInstanceSelectedFormat" xml:space="preserve"><value>当前游戏已切换为 {0}</value></data>
   <data name="Status_LaunchInstanceSelectionFailed" xml:space="preserve"><value>当前游戏切换失败，请刷新后重试。</value></data>
   <data name="Status_LoadingVersions" xml:space="preserve"><value>正在获取 Minecraft 版本列表...</value></data>
@@ -762,7 +761,6 @@
   <data name="Status_OpenLaunchReportFailed" xml:space="preserve"><value>无法打开本次游戏报告，请稍后重试。</value></data>
   <data name="Status_OpenGithubRepositoryFailed" xml:space="preserve"><value>打开 GitHub 仓库失败</value></data>
   <data name="Status_OpenFeedbackPageFailed" xml:space="preserve"><value>打开反馈页面失败，请稍后重试。</value></data>
-  <data name="Status_OpenMinecraftPurchasePageFailed" xml:space="preserve"><value>无法打开 Minecraft 购买页面，请稍后重试。</value></data>
   <data name="Status_OpenReferenceProjectFailed" xml:space="preserve"><value>打开项目链接失败</value></data>
   <data name="Status_OpenRelatedWebsiteFailed" xml:space="preserve"><value>打开相关网站失败</value></data>
   <data name="Status_OpenResourceDetailsFailed" xml:space="preserve"><value>无法打开资源详情，请稍后重试</value></data>
@@ -1028,7 +1026,6 @@
   <data name="Dialog_DeleteModsTitle" xml:space="preserve"><value>删除模组</value></data>
   <data name="Dialog_DeleteSingleModMessageFormat" xml:space="preserve"><value>确认删除模组“{0}”吗？将优先移入系统回收站；回收站不可用时将直接删除。</value></data>
   <data name="Dialog_DeleteMultipleModsMessageFormat" xml:space="preserve"><value>确认删除这 {0} 个模组吗？将优先移入系统回收站；回收站不可用时将直接删除。</value></data>
-  <data name="Status_ModEnabledStateTargetExistsFormat" xml:space="preserve"><value>{0}已存在，操作失败</value></data>
   <data name="Status_SelectedModsEnabledFormat" xml:space="preserve"><value>已启用 {0} 个模组</value></data>
   <data name="Status_SelectedModsEnablePartialFailedFormat" xml:space="preserve"><value>已启用 {0} 个模组，{1} 个失败</value></data>
   <data name="Status_SelectedModsEnableFailed" xml:space="preserve"><value>启用所选模组失败，请稍后重试。</value></data>

--- a/Launcher.App/Resources/Strings.zh-Hant.resx
+++ b/Launcher.App/Resources/Strings.zh-Hant.resx
@@ -1228,9 +1228,6 @@
   <data name="Account_AddButton" xml:space="preserve">
     <value>新增帳戶</value>
   </data>
-  <data name="Account_BuyMinecraftButton" xml:space="preserve">
-    <value>購買 Minecraft</value>
-  </data>
   <data name="Account_EmptySelection" xml:space="preserve">
     <value>選擇帳號以瀏覽或修改設定。</value>
   </data>
@@ -1406,7 +1403,7 @@
     <value>選擇要新增的帳戶類型。</value>
   </data>
   <data name="Dialog_AddOfflineAccountSubtitle" xml:space="preserve">
-    <value>如果您尚未擁有正版 Minecraft，請始終優先考慮購買正版 Minecraft。</value>
+    <value>輸入要新增的離線帳戶名。</value>
   </data>
   <data name="Dialog_AddMicrosoftAccountSubtitle" xml:space="preserve">
     <value>請在彈出的 Microsoft 官方頁面完成登入。</value>
@@ -1724,7 +1721,7 @@
     <value>遊戲已啟動，但離線皮膚載入失敗，本次將使用預設皮膚。</value>
   </data>
   <data name="Status_LaunchInstanceRepairFailed" xml:space="preserve">
-    <value>目前實例缺少關鍵檔案，且無法在不新增版本的情況下自動補齊，請重新安裝該實例或檢查版本檔案。</value>
+    <value>遊戲檔案驗證失敗。請啟用「缺少檔案自動補齊」後重試；若仍然失敗，請重新安裝此實例或檢查版本檔案。</value>
   </data>
   <data name="Status_LaunchInstanceSelectedFormat" xml:space="preserve">
     <value>目前遊戲已切換為 {0}</value>
@@ -2235,9 +2232,6 @@
   </data>
   <data name="Status_OpenFeedbackPageFailed" xml:space="preserve">
     <value>無法開啟意見回饋頁面，請稍後再試。</value>
-  </data>
-  <data name="Status_OpenMinecraftPurchasePageFailed" xml:space="preserve">
-    <value>無法開啟 Minecraft 購買頁面，請稍後再試。</value>
   </data>
   <data name="Status_OpenReferenceProjectFailed" xml:space="preserve">
     <value>開啟專案連結失敗</value>
@@ -3025,9 +3019,6 @@
   </data>
   <data name="Dialog_DeleteMultipleModsMessageFormat" xml:space="preserve">
     <value>確認刪除這 {0} 個模組嗎？將優先移至系統資源回收筒；資源回收筒無法使用時將直接刪除。</value>
-  </data>
-  <data name="Status_ModEnabledStateTargetExistsFormat" xml:space="preserve">
-    <value>{0}已存在，操作失敗</value>
   </data>
   <data name="Status_SelectedModsEnabledFormat" xml:space="preserve">
     <value>已啟用 {0} 個模組</value>


### PR DESCRIPTION
## Summary
- clarify that startup repair failures can be caused by failed game-file verification, not only missing instance files
- direct users to enable automatic missing-file repair and retry before reinstalling
- update the default, Simplified Chinese, Traditional Chinese, English, and Japanese strings

## Root cause
The affected launch failed during pre-launch validation because the shared asset index was corrupted. The prior message stated that the instance could not be repaired without adding a version, which did not match this recovery path.

## Validation
- `dotnet test Launcher.Tests/Launcher.Tests.csproj --no-restore --filter "FullyQualifiedName~StringResourceTests"` (4 passed)
- Full `dotnet test Launcher.sln` exceeded the three-minute execution limit during restore/build without reporting a test failure.

## Related issue
Related to #39.